### PR TITLE
perf: skip (method) bodies and non-javadoc comments

### DIFF
--- a/src/main/java/de/ialistannen/javadocapi/indexing/Indexer.java
+++ b/src/main/java/de/ialistannen/javadocapi/indexing/Indexer.java
@@ -5,6 +5,7 @@ import de.ialistannen.javadocapi.classpath.Pom;
 import de.ialistannen.javadocapi.classpath.PomClasspathDiscoverer;
 import de.ialistannen.javadocapi.classpath.PomParser;
 import de.ialistannen.javadocapi.spoon.JavadocElementExtractor;
+import de.ialistannen.javadocapi.spoon.JavadocLauncher;
 import de.ialistannen.javadocapi.spoon.filtering.IndexerFilterChain;
 import de.ialistannen.javadocapi.spoon.filtering.ParallelProcessor;
 import de.ialistannen.javadocapi.storage.ConfiguredGson;
@@ -37,7 +38,7 @@ public class Indexer {
     IndexerConfig config = ConfiguredGson.create().fromJson(configFileString, IndexerConfig.class);
 
     System.out.println(heading("Configuring spoon"));
-    Launcher launcher = new Launcher();
+    Launcher launcher = new JavadocLauncher();
     launcher.getEnvironment().setShouldCompile(false);
     launcher.getEnvironment().disableConsistencyChecks();
     launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);

--- a/src/main/java/de/ialistannen/javadocapi/indexing/Indexer.java
+++ b/src/main/java/de/ialistannen/javadocapi/indexing/Indexer.java
@@ -38,7 +38,12 @@ public class Indexer {
     IndexerConfig config = ConfiguredGson.create().fromJson(configFileString, IndexerConfig.class);
 
     System.out.println(heading("Configuring spoon"));
-    Launcher launcher = new JavadocLauncher();
+    Launcher launcher;
+    if (Boolean.getBoolean("keepFullAst")) {
+      launcher = new Launcher();
+    } else {
+      launcher = new JavadocLauncher();
+    }
     launcher.getEnvironment().setShouldCompile(false);
     launcher.getEnvironment().disableConsistencyChecks();
     launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);

--- a/src/main/java/de/ialistannen/javadocapi/spoon/JavadocLauncher.java
+++ b/src/main/java/de/ialistannen/javadocapi/spoon/JavadocLauncher.java
@@ -13,42 +13,43 @@ import java.util.Arrays;
 
 public class JavadocLauncher extends Launcher {
 
-    @Override
-    protected SpoonModelBuilder getCompilerInstance(Factory factory) {
-        return new Compiler(factory);
-    }
+  @Override
+  protected SpoonModelBuilder getCompilerInstance(Factory factory) {
+    return new Compiler(factory);
+  }
 
-    static class Compiler extends JDTBasedSpoonCompiler {
-        private final JDTTreeBuilder treeBuilder;
-        public Compiler(Factory factory) {
-            super(factory);
-            this.treeBuilder = new JDTTreeBuilder(factory) {
+  static class Compiler extends JDTBasedSpoonCompiler {
+    private final JDTTreeBuilder treeBuilder;
 
-                @Override
-                public boolean visit(MethodDeclaration methodDeclaration, ClassScope scope) {
-                    // avoid visiting method body
-                    methodDeclaration.statements = null;
-                    return super.visit(methodDeclaration, scope);
-                }
-            };
-        }
+    public Compiler(Factory factory) {
+      super(factory);
+      this.treeBuilder = new JDTTreeBuilder(factory) {
 
         @Override
-        protected void traverseUnitDeclaration(JDTTreeBuilder builder, CompilationUnitDeclaration unitDeclaration) {
-            // replace the tree builder with our own
-            super.traverseUnitDeclaration(this.treeBuilder, unitDeclaration);
-            // remove non-javadoc comments to avoid warnings from JDTCommentBuilder later
-            unitDeclaration.comments = reduceComments(unitDeclaration);
+        public boolean visit(MethodDeclaration methodDeclaration, ClassScope scope) {
+          // avoid visiting method body
+          methodDeclaration.statements = null;
+          return super.visit(methodDeclaration, scope);
         }
+      };
     }
 
-    static int[][] reduceComments(CompilationUnitDeclaration declaration) {
-        int[][] comments = declaration.comments;
-        if (comments == null) {
-            return null;
-        }
-        return Arrays.stream(comments)
-                .filter(comment -> comment[0] >= 0 && comment[1] >= 0)
-                .toArray(int[][]::new);
+    @Override
+    protected void traverseUnitDeclaration(JDTTreeBuilder builder, CompilationUnitDeclaration unitDeclaration) {
+      // replace the tree builder with our own
+      super.traverseUnitDeclaration(this.treeBuilder, unitDeclaration);
+      // remove non-javadoc comments to avoid warnings from JDTCommentBuilder later
+      unitDeclaration.comments = reduceComments(unitDeclaration);
     }
+  }
+
+  static int[][] reduceComments(CompilationUnitDeclaration declaration) {
+    int[][] comments = declaration.comments;
+    if (comments == null) {
+      return null;
+    }
+    return Arrays.stream(comments)
+        .filter(comment -> comment[0] >= 0 && comment[1] >= 0)
+        .toArray(int[][]::new);
+  }
 }

--- a/src/main/java/de/ialistannen/javadocapi/spoon/JavadocLauncher.java
+++ b/src/main/java/de/ialistannen/javadocapi/spoon/JavadocLauncher.java
@@ -1,0 +1,51 @@
+package de.ialistannen.javadocapi.spoon;
+
+import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
+import spoon.Launcher;
+import spoon.SpoonModelBuilder;
+import spoon.reflect.factory.Factory;
+import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
+import spoon.support.compiler.jdt.JDTTreeBuilder;
+
+import java.util.Arrays;
+
+public class JavadocLauncher extends Launcher {
+
+    @Override
+    protected SpoonModelBuilder getCompilerInstance(Factory factory) {
+        return new Compiler(factory);
+    }
+
+    static class Compiler extends JDTBasedSpoonCompiler {
+        private final JDTTreeBuilder treeBuilder;
+        public Compiler(Factory factory) {
+            super(factory);
+            this.treeBuilder = new JDTTreeBuilder(factory) {
+
+                @Override
+                public boolean visit(MethodDeclaration methodDeclaration, ClassScope scope) {
+                    methodDeclaration.statements = null;
+                    return super.visit(methodDeclaration, scope);
+                }
+            };
+        }
+
+        @Override
+        protected void traverseUnitDeclaration(JDTTreeBuilder builder, CompilationUnitDeclaration unitDeclaration) {
+            super.traverseUnitDeclaration(this.treeBuilder, unitDeclaration);
+            unitDeclaration.comments = reduceComments(unitDeclaration);
+        }
+    }
+
+    static int[][] reduceComments(CompilationUnitDeclaration declaration) {
+        int[][] comments = declaration.comments;
+        if (comments == null) {
+            return null;
+        }
+        return Arrays.stream(comments)
+                .filter(comment -> comment[0] >= 0 && comment[1] >= 0)
+                .toArray(int[][]::new);
+    }
+}

--- a/src/main/java/de/ialistannen/javadocapi/spoon/JavadocLauncher.java
+++ b/src/main/java/de/ialistannen/javadocapi/spoon/JavadocLauncher.java
@@ -26,6 +26,7 @@ public class JavadocLauncher extends Launcher {
 
                 @Override
                 public boolean visit(MethodDeclaration methodDeclaration, ClassScope scope) {
+                    // avoid visiting method body
                     methodDeclaration.statements = null;
                     return super.visit(methodDeclaration, scope);
                 }
@@ -34,7 +35,9 @@ public class JavadocLauncher extends Launcher {
 
         @Override
         protected void traverseUnitDeclaration(JDTTreeBuilder builder, CompilationUnitDeclaration unitDeclaration) {
+            // replace the tree builder with our own
             super.traverseUnitDeclaration(this.treeBuilder, unitDeclaration);
+            // remove non-javadoc comments to avoid warnings from JDTCommentBuilder later
             unitDeclaration.comments = reduceComments(unitDeclaration);
         }
     }


### PR DESCRIPTION
Before: <https://gceasy.io/my-gc-report.jsp?p=c2hhcmVkLzIwMjIvMDUvMS8tLWdjLmxvZy4wLS0xOC02LTM1>
After: <https://gceasy.io/my-gc-report.jsp?p=c2hhcmVkLzIwMjIvMDUvMi8tLWdjLmxvZy0tMTktMjYtMjM=>

Before: 
![before](https://user-images.githubusercontent.com/11150076/166312749-ef85c25e-cf51-4b4a-a1a2-14aaf160aee4.png)

After:
![after](https://user-images.githubusercontent.com/11150076/166312809-90a2c1c7-9fc6-4e02-a54c-401ed5a5bbd2.png)
(note that `buildModel` and `buildUnits` switch their positions)

Sidenote: The benchmark was made with spoon version `10.2.0-beta-3` to make use of the improved type adaption.

The changes can be disabled by using the `-DkeepFullAst=true` system property. It will use the default spoon Launcher instead of the modified one.
